### PR TITLE
Update vite dependency to v4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,35 @@
-{"author":"anonymous","devDependencies":{"@sveltejs/adapter-node":"^1.0.0-next.101","@sveltejs/adapter-static":"^1.0.0-next.48","@sveltejs/kit":"^1.0.0-next.562","concurrently":"^6.5.1","electron":"^12.2.3","electron-builder":"^22.14.13","electron-reloader":"^1.2.3","sass":"^1.56.1","svelte":"^3.53.1","svelte-preprocess":"^4.10.7","vite":"^3.2.4"},"license":"","private":true,"dependencies":{"electron-serve":"^1.1.0","electron-window-state":"^5.0.3"},"main":"src/electron.cjs","scripts":{"dev":"vite dev","package":"npm run build && electron-builder --config electron-builder.config.json","dev:package":"npm run build && electron-builder --config electron-builder.config.json --dir","electron":"concurrently --kill-others \"vite dev\" \"electron src/electron.cjs\"","preview":"vite preview","build":"vite build"},"version":"1.0.0","name":"electron-sveltekit","type":"module","description":"Electron and SvelteKit integration"}
+{
+  "author": "anonymous",
+  "devDependencies": {
+    "@sveltejs/adapter-node": "^1.0.0-next.101",
+    "@sveltejs/adapter-static": "^1.0.0-next.48",
+    "@sveltejs/kit": "^1.0.0-next.562",
+    "concurrently": "^6.5.1",
+    "electron": "^12.2.3",
+    "electron-builder": "^22.14.13",
+    "electron-reloader": "^1.2.3",
+    "sass": "^1.56.1",
+    "svelte": "^3.53.1",
+    "svelte-preprocess": "^4.10.7",
+    "vite": "^4.0.4"
+  },
+  "license": "",
+  "private": true,
+  "dependencies": {
+    "electron-serve": "^1.1.0",
+    "electron-window-state": "^5.0.3"
+  },
+  "main": "src/electron.cjs",
+  "scripts": {
+    "dev": "vite dev",
+    "package": "npm run build && electron-builder --config electron-builder.config.json",
+    "dev:package": "npm run build && electron-builder --config electron-builder.config.json --dir",
+    "electron": "concurrently --kill-others \"vite dev\" \"electron src/electron.cjs\"",
+    "preview": "vite preview",
+    "build": "vite build"
+  },
+  "version": "1.0.0",
+  "name": "electron-sveltekit",
+  "type": "module",
+  "description": "Electron and SvelteKit integration"
+}


### PR DESCRIPTION
Updating vite to v4 fixes the error below (sveltekit requires v4)

``
failed to load config from vite.config.js
error when starting dev server:
node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:6 import { isCSSRequest, loadEnv } from 'vite';
SyntaxError: The requested module 'vite' does not provide an export named 'isCSSRequest' ``

Once I made this change all of the scripts run without errors.